### PR TITLE
subheader and traits included

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,10 @@
 # Thommy Lee Jones (Actor)
 
+## love chocolate, music and football
+
+* friendly
+* innovative
+
 Tommy Lee Jones (born September 15, 1946) is an American actor and filmmaker. He has received four 
 Academy Award nominations, winning the Best Supporting Actor Oscar for his performance as U.S. Marshal 
 Samuel Gerard in the 1993 thriller film The Fugitive.

--- a/index.md
+++ b/index.md
@@ -1,9 +1,10 @@
 # Thommy Lee Jones (Actor)
 
-## love chocolate, music and football
+## love chocolate, music and football, football, football, football, football
 
 * friendly
 * innovative
+* innocent
 
 Tommy Lee Jones (born September 15, 1946) is an American actor and filmmaker. He has received four 
 Academy Award nominations, winning the Best Supporting Actor Oscar for his performance as U.S. Marshal 


### PR DESCRIPTION
Problem:
Webpage without subheader

Solved:
Subheader included

Files involved:
index.md

#6 fixes:  